### PR TITLE
Added VariationalAutoencoder wrapper for torch.nn.Module

### DIFF
--- a/test/unit/models/test_encoders.py
+++ b/test/unit/models/test_encoders.py
@@ -2,6 +2,7 @@ import torch
 
 from drumblender.models.encoders import DummyParameterEncoder
 from drumblender.models.encoders import ModalAmpParameters
+from drumblender.models.encoders import VariationalEncoder
 
 
 def test_dummy_parameter_encoder_can_be_instantiated():
@@ -28,3 +29,16 @@ def test_modal_amp_parameters_can_forward():
 
     output = model(fake_modal_params)
     assert output.shape == (batch_size, num_params, num_modes, num_steps)
+
+
+def test_variational_encoder_yields_correct_sizes():
+    batch_size = 16
+    distr_len = 1024
+    encoder = DummyParameterEncoder((batch_size, distr_len))
+    variational_encoder = VariationalEncoder(encoder)
+
+    z = variational_encoder(torch.rand(1, 1))
+    sampled_z, kl = variational_encoder.reparametrize(z)
+    assert sampled_z.shape[0] == batch_size
+    assert sampled_z.shape[1] == distr_len // 2
+    assert len(kl.shape) == 0


### PR DESCRIPTION
Added a wrapper adapted from the RAVE repo for a standard nn.Module encoder that is assumed that parameterizes a multimodal Gaussian distribution. It also assumes the underlying data distribution is multimodal gaussian with zero mean and unit std. With this, we easily compute the KL divergence which we can also return with this module.

A good source about the KL div:
http://www.cs.cmu.edu/afs/cs/user/bhiksha/WWW/courses/deeplearning/Fall.2018/www/recitations/rec10.vae.pdf

Computing KL div between two Gaussian Distributions (works for multivariate Gaussians too)
https://stats.stackexchange.com/questions/7440/kl-divergence-between-two-univariate-gaussians

